### PR TITLE
Suppress PHP deprecation notices during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ This will compile the necessary PHP extensions, including the Phalcon
 extension, and drop you into a container where you can run the framework
 or its test suite.
 
+## Testing
+
+Run the test suite using the helper script to hide PHP deprecation warnings:
+
+```
+bin/pest
+```
+
 ## License
 
 This project is open-sourced under the MIT license.

--- a/bin/pest
+++ b/bin/pest
@@ -1,0 +1,4 @@
+#!/usr/bin/env php
+<?php
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+require __DIR__.'/../vendor/pestphp/pest/bin/pest';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,5 +18,6 @@
 
         <env name="CACHE_DRIVER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED &amp; ~E_USER_DEPRECATED"/>
     </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- add a small wrapper script for running Pest
- suppress deprecated warnings in PHPUnit configuration
- document how to run the test suite without PHP deprecation output

## Testing
- `bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_687075db1ce48330a43b1dd33cd3cc1d