### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENT Instructions
+
+## Testing
+
+Run tests using `bin/pest`.
+
+## Formatting
+
+Run `./vendor/bin/pint` to format PHP code.
+
+## Dependencies
+
+If dependencies are missing, run `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-phalcon --ignore-platform-req=ext-redis`.
+
+## PR Message
+
+The PR description must contain a **Summary** section describing the change and a **Testing** section explaining how checks were run and their results.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for running tests and formatting

## Testing
- `./vendor/bin/pint`
- `bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68785a30f64883309e56160d6ed36ce3