### PR TITLE
Remove PHP 8.4 features

### DIFF
--- a/src/Phare/Console/Helpers/Creator.php
+++ b/src/Phare/Console/Helpers/Creator.php
@@ -50,8 +50,10 @@ abstract class Creator
      */
     protected function outputNothingCreated(array $bools): void
     {
-        if (array_any($bools, fn ($bool) => $bool)) {
-            return;
+        foreach ($bools as $bool) {
+            if ($bool) {
+                return;
+            }
         }
 
         $this->output->writeComment(

--- a/src/Phare/Routing/ControllerRouteLoader.php
+++ b/src/Phare/Routing/ControllerRouteLoader.php
@@ -112,7 +112,13 @@ class ControllerRouteLoader extends RouteLoader
 
     private function isUnderPaths(string $filePath, array $paths): bool
     {
-        return array_any($paths, fn ($path) => str_starts_with($filePath, $path));
+        foreach ($paths as $path) {
+            if (str_starts_with($filePath, $path)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function buildClassName($file, string $baseDir, string $namespace): ?string

--- a/src/Phare/Support/helpers.php
+++ b/src/Phare/Support/helpers.php
@@ -1,5 +1,19 @@
 <?php
 
+// Polyfills for PHP 8.4 functions
+if (!function_exists('array_any')) {
+    function array_any(array $array, callable $callback): bool
+    {
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 // config()
 if (!function_exists('config')) {
     function config($key = null, $default = null)
@@ -271,49 +285,49 @@ if (!function_exists('session')) {
 
 // Path helpers
 if (!function_exists('base_path')) {
-    function base_path($path = "")
+    function base_path($path = '')
     {
-        return app()->basePath("" . $path);
+        return app()->basePath('' . $path);
     }
 }
 if (!function_exists('storage_path')) {
-    function storage_path($path = "")
+    function storage_path($path = '')
     {
-        return app()->basePath("storage/" . $path);
+        return app()->basePath('storage/' . $path);
     }
 }
 if (!function_exists('database_path')) {
-    function database_path($path = "")
+    function database_path($path = '')
     {
-        return app()->basePath("database/" . $path);
+        return app()->basePath('database/' . $path);
     }
 }
 if (!function_exists('public_path')) {
-    function public_path($path = "")
+    function public_path($path = '')
     {
-        return app()->basePath("public/" . $path);
+        return app()->basePath('public/' . $path);
     }
 }
 if (!function_exists('resource_path')) {
-    function resource_path($path = "")
+    function resource_path($path = '')
     {
-        return app()->basePath("resource/" . $path);
+        return app()->basePath('resource/' . $path);
     }
 }
 if (!function_exists('lang_path')) {
-    function lang_path($path = "")
+    function lang_path($path = '')
     {
-        return app()->basePath("lang/" . $path);
+        return app()->basePath('lang/' . $path);
     }
 }
 if (!function_exists('config_path')) {
-    function config_path($path = "")
+    function config_path($path = '')
     {
         return app()->configPath($path);
     }
 }
 if (!function_exists('bootstrap_path')) {
-    function bootstrap_path($path = "")
+    function bootstrap_path($path = '')
     {
         return app()->bootstrapPath($path);
     }


### PR DESCRIPTION
## Summary
- drop usages of `array_any`
- polyfill `array_any` for older PHP versions

## Testing
- `composer install --ignore-platform-req=ext-gmp --ignore-platform-req=ext-phalcon --ignore-platform-req=ext-redis`
- `./vendor/bin/pint src/Phare/Support/helpers.php src/Phare/Routing/ControllerRouteLoader.php src/Phare/Console/Helpers/Creator.php`
- `bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_688746bd33788330b7712907623d2374